### PR TITLE
Fix grid item bottom spacing bug

### DIFF
--- a/app/src/main/java/com/teco/note/util/GridDividerItemDecoration.kt
+++ b/app/src/main/java/com/teco/note/util/GridDividerItemDecoration.kt
@@ -21,7 +21,10 @@ class GridDividerItemDecoration(private val spacing: Int) : RecyclerView.ItemDec
         outRect.top = if (isInTheFirstRow(position, totalSpanCount)) 0 else spacing
         outRect.left = if (isFirstInRow(position, totalSpanCount, spanSize)) spacing / 4 else spacing / 2
         outRect.right = if (isLastInRow(position, totalSpanCount, spanSize)) spacing / 4 else spacing / 2
-        outRect.bottom = if (isLastInRow(position, totalSpanCount, spanSize)) spanSize else 0
+        // Always add bottom spacing. Using spanSize here resulted in items having
+        // inconsistent bottom offsets depending on the column they were placed in
+        // which produced visible layout glitches.
+        outRect.bottom = spacing
     }
 
     private fun isInTheFirstRow(position: Int, totalSpanCount: Int): Boolean =


### PR DESCRIPTION
## Summary
- fix incorrect bottom offset in `GridDividerItemDecoration`

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6840181a3fbc8333a72dbe4680e48481