### PR TITLE
Fix password validation string ID

### DIFF
--- a/app/src/main/java/com/teco/note/ui/create_account/CreateAccountActivity.kt
+++ b/app/src/main/java/com/teco/note/ui/create_account/CreateAccountActivity.kt
@@ -41,7 +41,7 @@ class CreateAccountActivity :
                     }
 
                     CreateAccountViewModel.CreateAccountUIStates.InvalidPassword -> {
-                        binding.tilPassword.error = getString(R.string.enter_valid_passowrd)
+                        binding.tilPassword.error = getString(R.string.enter_valid_password)
                     }
 
                     CreateAccountViewModel.CreateAccountUIStates.Loading -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="already_have_account">Already have account..</string>
     <string name="sign_up">Sign Up</string>
     <string name="enter_valid_email">Please enter valid email address</string>
-    <string name="enter_valid_passowrd">Password must be 8 character long, including alphabets and numbers without space</string>
+    <string name="enter_valid_password">Password must be at least 8 characters long, including letters and numbers with no spaces.</string>
     <string name="enter_conf_password">Please enter confirm password</string>
     <string name="confirm_password_must_be_same">Confirm password must be same as password</string>
     <string name="enter_email">Please enter email address</string>


### PR DESCRIPTION
## Summary
- rename `enter_valid_passowrd` to `enter_valid_password`
- update message text for password validation
- update Kotlin code to use the renamed string

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68401af0cce483338272df61f600f3a6