### PR TITLE
Fix bottom offset in GridDividerItemDecoration

### DIFF
--- a/app/src/main/java/com/teco/note/util/GridDividerItemDecoration.kt
+++ b/app/src/main/java/com/teco/note/util/GridDividerItemDecoration.kt
@@ -21,7 +21,7 @@ class GridDividerItemDecoration(private val spacing: Int) : RecyclerView.ItemDec
         outRect.top = if (isInTheFirstRow(position, totalSpanCount)) 0 else spacing
         outRect.left = if (isFirstInRow(position, totalSpanCount, spanSize)) spacing / 4 else spacing / 2
         outRect.right = if (isLastInRow(position, totalSpanCount, spanSize)) spacing / 4 else spacing / 2
-        outRect.bottom = if (isLastInRow(position, totalSpanCount, spanSize)) spanSize else 0
+        outRect.bottom = if (isLastInRow(position, totalSpanCount, spanSize)) spacing else 0
     }
 
     private fun isInTheFirstRow(position: Int, totalSpanCount: Int): Boolean =


### PR DESCRIPTION
## Summary
- fix bottom offset calculation for grid divider

## Testing
- `./gradlew :app:assembleDebug` *(fails: unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68401b825678833382e77c3c47cf36fb