### PR TITLE
Fix README typos and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Tecocraft Note App
-## Native android application that has functionality to create, update, delete and store notes based on firebase.
+## Native Android application that lets you create, update, delete, and store notes using Firebase.
 
 [![N|Solid](https://www.tecocraft.com/wp-content/uploads/2022/05/Tecocraft-logo-header.png)](https://www.tecocraft.com/)
 
-Tecocraft note app is note app, in which user can create notes to markdown things, also this app based on firebase authentication and storage, so user can see his/her notes by loging from multiple devices.
+Tecocraft Note App lets users create markdown notes. It uses Firebase for authentication and storage, so users can see their notes by logging in from multiple devices.
 
 ## Functionalities
 
-- Firebase authentication (email-password)
-- Firestore database (To store User's notes)
-- MVVM architecture (with Viewmodel, Stateflow, Dependency injection using hilt)
+- Firebase authentication (email/password)
+- Firestore database (to store users' notes)
+- MVVM architecture (with ViewModel, StateFlow, and dependency injection using Hilt)
 - Material 3 theme and UI elements
-- Splash screen API
+- Splash Screen API
 
 ## Screenshots
 [![Screenshot-20230608-113719.png](https://i.postimg.cc/T3Lh2FrV/Screenshot-20230608-113719.png)](https://postimg.cc/LJSmNyQ5)   [![Screenshot-20230608-114826.png](https://i.postimg.cc/HxXXpCZK/Screenshot-20230608-114826.png)](https://postimg.cc/WFphnxP6)   [![Screenshot-20230608-115015.png](https://i.postimg.cc/9Q9WgFrv/Screenshot-20230608-115015.png)](https://postimg.cc/dhqPLFRB)  [![Screenshot-20230608-114955.png](https://i.postimg.cc/qqmRrbTS/Screenshot-20230608-114955.png)](https://postimg.cc/p5FxYByJ) [![Screenshot-20230608-115033.png](https://i.postimg.cc/vZwRB7ZN/Screenshot-20230608-115033.png)](https://postimg.cc/SJd11M86) [![Screenshot-20230608-115045.png](https://i.postimg.cc/GmV8kdcg/Screenshot-20230608-115045.png)](https://postimg.cc/cv7LWqtf)


### PR DESCRIPTION
## Summary
- fix spelling mistake 'logging' in README
- revise README header and description
- cleanup wording and bullet list grammar

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68401c6ebf648333b0969a68ff5067ab